### PR TITLE
Implement k cloud platform env command

### DIFF
--- a/lib/kontena/plugin/cloud/platform/env_command.rb
+++ b/lib/kontena/plugin/cloud/platform/env_command.rb
@@ -1,0 +1,9 @@
+require_relative 'common'
+
+class Kontena::Plugin::Cloud::Platform::EnvCommand < Kontena::Command
+  include Kontena::Cli::Common
+
+  def execute
+    Kontena.run!(['grid','env'])
+  end
+end

--- a/lib/kontena/plugin/cloud/platform_command.rb
+++ b/lib/kontena/plugin/cloud/platform_command.rb
@@ -7,6 +7,7 @@ class Kontena::Plugin::Cloud::PlatformCommand < Kontena::Command
   subcommand ['join', 'byo'], 'Join grid as Kontena Platform', load_subcommand('kontena/plugin/cloud/platform/import_grid_command')
   subcommand 'user', 'User management commands', load_subcommand('kontena/plugin/cloud/platform/user_command')
   subcommand 'upgrade', 'Upgrade platform version', load_subcommand('kontena/plugin/cloud/platform/upgrade_command')
+  subcommand 'env', 'Show the current grid environment details', load_subcommand('kontena/plugin/cloud/platform/env_command')
 
   def execute
   end


### PR DESCRIPTION
This PR adds missing `k cloud platform env` command that returns `KONTENA_URI` and `KONTENA_TOKEN`.