### PR TITLE
Cloud node sub-commands

### DIFF
--- a/lib/kontena/cli/models/node.rb
+++ b/lib/kontena/cli/models/node.rb
@@ -1,0 +1,15 @@
+require_relative 'cloud_api_model'
+
+module Kontena::Cli::Models
+  class Node
+    include CloudApiModel
+
+    def platform_id
+      @api_data.dig('relationships', 'platform', 'data', 'id')
+    end
+
+    def organization_id
+      @api_data.dig('relationships', 'organization', 'data', 'id')
+    end
+  end
+end

--- a/lib/kontena/plugin/cloud.rb
+++ b/lib/kontena/plugin/cloud.rb
@@ -9,6 +9,8 @@ module Kontena
 
       module Region; end
 
+      module Node; end
+
       module Platform
         module User; end
       end

--- a/lib/kontena/plugin/cloud/node/common.rb
+++ b/lib/kontena/plugin/cloud/node/common.rb
@@ -1,0 +1,42 @@
+require_relative '../../../cli/models/node'
+require_relative '../../../cli/models/platform'
+
+module Kontena::Plugin::Cloud::Node::Common
+
+  def self.included(base)
+    if base.respond_to?(:option)
+      base.option '--platform', 'PLATFORM', 'Specify Kontena Cloud platform to use' do |platform|
+        config.current_master = platform
+        config.current_grid = platform.split('/')[1]
+      end
+    end
+  end
+
+  def compute_client
+    @compute_client ||= Kontena::Client.new(compute_url, config.current_account.token, prefix: '/')
+  end
+
+  def config
+    Kontena::Cli::Config.instance
+  end
+
+  def compute_url
+    ENV['COMPUTE_URL'] || 'https://compute.kontena.io'
+  end
+
+  def get_platform(org, id)
+    unless cached_platforms_by_id[id]
+      data = cloud_client.get("/organizations/#{org}/platforms/#{id}")['data']
+      if data
+        platform = Kontena::Cli::Models::Platform.new(data)
+        cached_platforms_by_id[id] = platform
+      end
+    end
+
+    cached_platforms_by_id[id]
+  end
+
+  def cached_platforms_by_id
+    @cached_platforms_by_id ||= {}
+  end
+end

--- a/lib/kontena/plugin/cloud/node/create_command.rb
+++ b/lib/kontena/plugin/cloud/node/create_command.rb
@@ -1,0 +1,84 @@
+require 'kontena/machine/random_name'
+require_relative 'common'
+require_relative '../organization/common'
+require_relative '../platform/common'
+
+class Kontena::Plugin::Cloud::Node::CreateCommand < Kontena::Command
+  include Kontena::Cli::Common
+  include Kontena::Machine::RandomName
+  include Kontena::Plugin::Cloud::Node::Common
+  include Kontena::Plugin::Cloud::Organization::Common
+  include Kontena::Plugin::Cloud::Platform::Common
+
+  NODE_TYPES = {
+    'k1' => '1CPU, 1GB, 30GB SSD',
+    'k2' => '1CPU, 2GB, 60GB SSD',
+    'k4' => '2CPU, 4GB, 120GB SSD',
+    'k8' => '2CPU, 8GB, 240GB SSD',
+    'k16' => '4CPU, 16GB, 480GB SSD'
+  }
+
+  requires_current_account_token
+
+  option "--count", "COUNT", "How many nodes to create" do |count|
+    Integer(count)
+  end
+  option "--type", "TYPE", "Node type (k1, k2, k4, k8, k16)", required: true
+  option "--region", "REGION", "Region (us-east-1, eu-west-1, defaults to platform region)"
+
+  def execute
+    org, platform = parse_platform_name(current_master.name)
+    platform = require_platform("#{org}/#{platform}")
+    grid = client.get("grids/#{current_grid}")
+    self.count.times do
+      create_node(platform, grid['token'])
+    end
+  end
+
+  def create_node(platform, token)
+    name = "#{generate_name}-#{rand(1..999)}"
+    node_token = SecureRandom.hex(32)
+    spinner "Registering node #{pastel.cyan(name)} to platform #{pastel.cyan(platform.to_path)}"
+    client.post("grids/#{current_grid}/nodes", {
+      name: name,
+      token: node_token
+    })
+
+    data = {
+      type: 'nodes',
+      attributes: {
+        name: name,
+        type: self.type,
+        region: platform.region,
+        tokens: {
+          grid: token,
+          node: node_token
+        }
+      },
+      relationships: {
+        platform: {
+          data: {
+            type: 'platforms',
+            id: platform.id
+          }
+        }
+      }
+    }
+    spinner "Provisioning node #{pastel.cyan(name)} to region #{pastel.cyan(self.region)}" do
+      compute_client.post("/organizations/#{current_organization}/nodes", { data: data })
+    end
+  end
+
+  def default_count
+    prompt.ask("How many nodes?", default: 1)
+  end
+
+  def default_type
+    prompt.select("Choose node type:") do |menu|
+      menu.default 3
+      NODE_TYPES.each do |id, name|
+        menu.choice "#{id} (#{name})", id
+      end
+    end
+  end
+end

--- a/lib/kontena/plugin/cloud/node/create_command.rb
+++ b/lib/kontena/plugin/cloud/node/create_command.rb
@@ -70,7 +70,7 @@ class Kontena::Plugin::Cloud::Node::CreateCommand < Kontena::Command
   end
 
   def default_count
-    prompt.ask("How many nodes?", default: 1)
+    prompt.ask("How many nodes?", default: 1).to_i
   end
 
   def default_type

--- a/lib/kontena/plugin/cloud/node/create_command.rb
+++ b/lib/kontena/plugin/cloud/node/create_command.rb
@@ -70,7 +70,7 @@ class Kontena::Plugin::Cloud::Node::CreateCommand < Kontena::Command
     prompt.select("Choose node type:") do |menu|
       menu.default 3
       node_types.each do |t|
-        menu.choice "#{t['id']} (#{t.dig('attributes', 'cpus')}xCPU, #{t.dig('attributes', 'memory')}GB, #{t.dig('attributes', 'disk')}GB SSD)"
+        menu.choice "#{t['id']} (#{t.dig('attributes', 'cpus')}xCPU, #{t.dig('attributes', 'memory')}GB, #{t.dig('attributes', 'disk')}GB SSD)", t['id']
       end
     end
   end

--- a/lib/kontena/plugin/cloud/node/create_command.rb
+++ b/lib/kontena/plugin/cloud/node/create_command.rb
@@ -39,7 +39,7 @@ class Kontena::Plugin::Cloud::Node::CreateCommand < Kontena::Command
     name = "#{generate_name}-#{rand(1..999)}"
     node_token = SecureRandom.hex(32)
     target_region = self.region || platform.region
-    spinner "Provisioning node #{pastel.cyan(name)} to platform #{pastel.cyan(platform.to_path)}, region #{pastel.cyan(target_region)}" do
+    spinner "Provisioning a node #{pastel.cyan(name)} to platform #{pastel.cyan(platform.to_path)}, region #{pastel.cyan(target_region)}" do
       client.post("grids/#{current_grid}/nodes", {
         name: name,
         token: node_token

--- a/lib/kontena/plugin/cloud/node/create_command.rb
+++ b/lib/kontena/plugin/cloud/node/create_command.rb
@@ -38,33 +38,32 @@ class Kontena::Plugin::Cloud::Node::CreateCommand < Kontena::Command
   def create_node(platform, token)
     name = "#{generate_name}-#{rand(1..999)}"
     node_token = SecureRandom.hex(32)
-    spinner "Registering node #{pastel.cyan(name)} to platform #{pastel.cyan(platform.to_path)}"
-    client.post("grids/#{current_grid}/nodes", {
-      name: name,
-      token: node_token
-    })
-
-    data = {
-      type: 'nodes',
-      attributes: {
+    spinner "Provisioning node #{pastel.cyan(name)} to platform #{pastel.cyan(platform.to_path)}, region #{pastel.cyan(self.region)}" do
+      client.post("grids/#{current_grid}/nodes", {
         name: name,
-        type: self.type,
-        region: platform.region,
-        tokens: {
-          grid: token,
-          node: node_token
-        }
-      },
-      relationships: {
-        platform: {
-          data: {
-            type: 'platforms',
-            id: platform.id
+        token: node_token
+      })
+
+      data = {
+        type: 'nodes',
+        attributes: {
+          name: name,
+          type: self.type,
+          region: platform.region,
+          tokens: {
+            grid: token,
+            node: node_token
+          }
+        },
+        relationships: {
+          platform: {
+            data: {
+              type: 'platforms',
+              id: platform.id
+            }
           }
         }
       }
-    }
-    spinner "Provisioning node #{pastel.cyan(name)} to region #{pastel.cyan(self.region)}" do
       compute_client.post("/organizations/#{current_organization}/nodes", { data: data })
     end
   end

--- a/lib/kontena/plugin/cloud/node/create_command.rb
+++ b/lib/kontena/plugin/cloud/node/create_command.rb
@@ -38,7 +38,8 @@ class Kontena::Plugin::Cloud::Node::CreateCommand < Kontena::Command
   def create_node(platform, token)
     name = "#{generate_name}-#{rand(1..999)}"
     node_token = SecureRandom.hex(32)
-    spinner "Provisioning node #{pastel.cyan(name)} to platform #{pastel.cyan(platform.to_path)}, region #{pastel.cyan(self.region)}" do
+    target_region = self.region || platform.region
+    spinner "Provisioning node #{pastel.cyan(name)} to platform #{pastel.cyan(platform.to_path)}, region #{pastel.cyan(target_region)}" do
       client.post("grids/#{current_grid}/nodes", {
         name: name,
         token: node_token
@@ -49,7 +50,7 @@ class Kontena::Plugin::Cloud::Node::CreateCommand < Kontena::Command
         attributes: {
           name: name,
           type: self.type,
-          region: platform.region,
+          region: target_region,
           tokens: {
             grid: token,
             node: node_token

--- a/lib/kontena/plugin/cloud/node/list_command.rb
+++ b/lib/kontena/plugin/cloud/node/list_command.rb
@@ -1,0 +1,49 @@
+require_relative 'common'
+require_relative '../organization/common'
+require_relative '../platform/common'
+
+class Kontena::Plugin::Cloud::Node::ListCommand < Kontena::Command
+  include Kontena::Cli::Common
+  include Kontena::Cli::TableGenerator::Helper
+  include Kontena::Plugin::Cloud::Node::Common
+  include Kontena::Plugin::Cloud::Platform::Common
+  include Kontena::Plugin::Cloud::Organization::Common
+
+  requires_current_account_token
+
+  def execute
+    org, platform = parse_platform_name(current_master.name)
+    platform = require_platform("#{org}/#{platform}")
+    nodes = compute_client.get("/organizations/#{org}/nodes")['data']
+    nodes.delete_if { |n| n.dig('attributes', 'state') == 'terminated' }
+    print_table(nodes) do |n|
+      node = Kontena::Cli::Models::Node.new(n)
+      n['name'] = "#{state_icon(node.state)} #{node.name}"
+      n['type'] = node.type
+      n['region'] = node.region
+    end
+  end
+
+  def default_organization
+    prompt_organization
+  end
+
+  def fields
+    {
+      'name' => 'name',
+      'type' => 'type',
+      'region' => 'region'
+    }
+  end
+
+  def state_icon(state)
+    case state
+    when nil
+      " ".freeze
+    when 'running'.freeze
+      pastel.green('⊛'.freeze)
+    else
+      pastel.dark('⊝'.freeze)
+    end
+  end
+end

--- a/lib/kontena/plugin/cloud/node/shell_command.rb
+++ b/lib/kontena/plugin/cloud/node/shell_command.rb
@@ -1,0 +1,58 @@
+require_relative 'common'
+require_relative '../organization/common'
+require_relative '../platform/common'
+
+class Kontena::Plugin::Cloud::Node::ShellCommand < Kontena::Command
+  include Kontena::Cli::Common
+  include Kontena::Plugin::Cloud::Platform::Common
+  include Kontena::Plugin::Cloud::Node::Common
+
+  requires_current_account_token
+
+  parameter "NAME", "Node name"
+
+  def execute
+    service_name = "#{name}-shell-#{rand(1..10_000)}"
+
+    service = nil
+    spinner "Creating shell session to node #{pastel.cyan(name)}" do
+      service = create_service(service_name, name)
+    end
+
+    Kontena.run!([
+      'service', 'exec', '-it', '--shell', service_name,
+      'nsenter --target 1 --mount --uts --net --pid -- su - core'
+    ])
+  ensure
+    remove_service(service) if service
+  end
+
+  def create_service(service_name, node_name)
+    data = {
+      name: service_name,
+      image: 'kontena/nsenter:latest',
+      stateful: false,
+      cmd: ['sleep', '60000'],
+      pid: 'host',
+      privileged: true,
+      affinity: [
+        "node==#{node_name}"
+      ],
+      env: [
+        "TERM=xterm"
+      ]
+    }
+    service = client.post("grids/#{current_grid}/services", data)
+    deployment = client.post("services/#{service['id']}/deploy", {})
+    until deployment['finished_at'] do
+      sleep 1
+      deployment = client.get("services/#{service['id']}/deploys/#{deployment['id']}", {})
+    end
+
+    service
+  end
+
+  def remove_service(service)
+    client.delete("services/#{service['id']}", {})
+  end
+end

--- a/lib/kontena/plugin/cloud/node/terminate_command.rb
+++ b/lib/kontena/plugin/cloud/node/terminate_command.rb
@@ -1,0 +1,62 @@
+require_relative 'common'
+require_relative '../organization/common'
+require_relative '../platform/common'
+
+class Kontena::Plugin::Cloud::Node::TerminateCommand < Kontena::Command
+  include Kontena::Cli::Common
+  include Kontena::Plugin::Cloud::Platform::Common
+  include Kontena::Plugin::Cloud::Node::Common
+
+  requires_current_account_token
+
+  parameter "[NAME]", "Node name"
+  option "--force", :flag, "Force remove", default: false, attribute_name: :forced
+
+  def execute
+    org, platform = parse_platform_name(current_master.name)
+    unless self.name
+      name = prompt_name(platform, org)
+    else
+      exit_with_error "Invalid name" if org.nil? || platform.nil?
+      name = self.name
+    end
+
+    confirm_command(name) unless forced?
+
+    nodes = compute_client.get("/organizations/#{org}/nodes")['data'].map { |n|
+      Kontena::Cli::Models::Node.new(n)
+    }
+    node = nodes.find { |n| n.name == name }
+    exit_with_error "Node not found" unless node
+
+    spinner "Terminating node #{pastel.cyan(node.name)} from platform #{pastel.cyan("#{org}/#{platform}")}" do
+      compute_client.delete("/organizations/#{org}/nodes/#{node.id}")
+    end
+    platform = get_platform(org, node.platform_id)
+    if platform
+      client.delete("nodes/#{current_grid}/#{name}")
+    end
+  end
+
+  def prompt_name(platform, org)
+    platform = find_platform_by_name(platform, org)
+    exit_with_error "Platform not selected" unless platform
+
+    nodes = compute_client.get("/organizations/#{org}/nodes")['data'].map { |n|
+      Kontena::Cli::Models::Node.new(n)
+    }
+    nodes.delete_if { |n| n.platform_id != platform.id || n.state == 'terminated' }
+    exit_with_error "No nodes" if nodes.size == 0
+    grid_nodes = client.get("grids/#{current_grid}/nodes")['nodes']
+    prompt.select("Choose node") do |menu|
+      nodes.each do |node|
+        grid_node = grid_nodes.find { |n| n['name'] == node.name }
+        if grid_node
+          menu.choice "#{node.name} #{grid_node['initial_member'] ? '(initial)' : ''}", node.name
+        else
+          menu.choice "#{node.name} (orphan)", node.name
+        end
+      end
+    end
+  end
+end

--- a/lib/kontena/plugin/cloud/node_command.rb
+++ b/lib/kontena/plugin/cloud/node_command.rb
@@ -1,0 +1,10 @@
+class Kontena::Plugin::Cloud::NodeCommand < Kontena::Command
+
+  subcommand ['list', 'ls'], 'List cloud nodes', load_subcommand('kontena/plugin/cloud/node/list_command')
+  subcommand ['shell'], 'Jump into node shell', load_subcommand('kontena/plugin/cloud/node/shell_command')
+  subcommand ['create'], 'Create cloud node', load_subcommand('kontena/plugin/cloud/node/create_command')
+  subcommand ['terminate'], 'Terminate cloud node', load_subcommand('kontena/plugin/cloud/node/terminate_command')
+
+  def execute
+  end
+end

--- a/lib/kontena/plugin/cloud/platform/common.rb
+++ b/lib/kontena/plugin/cloud/platform/common.rb
@@ -52,9 +52,7 @@ module Kontena::Plugin::Cloud::Platform::Common
     p = find_platform_by_name(platform, org)
     exit_with_error("Platform not found") unless p
     unless platform_config_exists?(p.to_path)
-      spinner "Generating platform token" do
-        login_to_platform("#{current_organization}/#{platform}", p.url)
-      end
+      login_to_platform("#{current_organization}/#{platform}", p.url)
     end
     self.current_master = "#{current_organization}/#{platform}"
     self.current_grid = p.grid_id

--- a/lib/kontena/plugin/cloud_command.rb
+++ b/lib/kontena/plugin/cloud_command.rb
@@ -1,6 +1,7 @@
 class Kontena::Cli::CloudCommand < Kontena::Command
 
   subcommand 'platform', 'Kontena platform specific commands', load_subcommand('kontena/plugin/cloud/platform_command')
+  subcommand 'node', 'Kontena node specific commands', load_subcommand('kontena/plugin/cloud/node_command')
   subcommand ['organization', 'org'], 'Organization specific commands', load_subcommand('kontena/plugin/cloud/organization_command')
   subcommand 'region', 'Region specific commands', load_subcommand('kontena/plugin/cloud/region_command')
 


### PR DESCRIPTION
```
$ kontena cloud node
Usage:
    kontena cloud node [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    list, ls                      List cloud nodes
    shell                         Jump into node shell
    create                        Create cloud node
    terminate                     Terminate cloud node
```

```
$ kontena cloud node create --help
Usage:
    kontena cloud node create [OPTIONS]

Options:
    --platform PLATFORM           Specify Kontena Cloud platform to use
    --count COUNT                 How many nodes to create
    --type TYPE                   Node type
    --region REGION               Region (us-east-1, eu-west-1, defaults to current platform region)
```