### PR TITLE
Fix cloud token env variable

### DIFF
--- a/lib/kontena_cli_plugin.rb
+++ b/lib/kontena_cli_plugin.rb
@@ -13,7 +13,7 @@ module Kontena
             config.current_master = platform
             config.current_grid = platform.split('/')[1]
           end
-          #base.option '--grid', 'GRID', 'Specify grid to use'
+          base.option '--grid', 'GRID', 'Specify grid to use'
         end
       end
     end

--- a/lib/kontena_cli_plugin.rb
+++ b/lib/kontena_cli_plugin.rb
@@ -13,7 +13,45 @@ module Kontena
             config.current_master = platform
             config.current_grid = platform.split('/')[1]
           end
-          base.option '--grid', 'GRID', 'Specify grid to use'
+          #base.option '--grid', 'GRID', 'Specify grid to use'
+        end
+      end
+    end
+
+    class Config
+
+      # patch broken cli
+      unless self.instance_methods.include?(:load_cloud_settings_from_env)
+
+        def load_settings_from_env
+          load_cloud_settings_from_env
+          load_master_settings_from_env
+        end
+
+        def load_master_settings_from_env
+          return nil unless ENV['KONTENA_URL']
+
+          debug { 'Loading master configuration from ENV' }
+          servers << Server.new(
+            url: ENV['KONTENA_URL'],
+            name: 'default',
+            token: Token.new(access_token: ENV['KONTENA_TOKEN'], parent_type: :master, parent_name: 'default'),
+            grid: ENV['KONTENA_GRID'],
+            parent_type: :master,
+            parent_name: 'default'
+          )
+
+          self.current_master  = 'default'
+          self.current_account = 'kontena'
+        end
+
+        def load_cloud_settings_from_env
+          return unless ENV['KONTENA_CLOUD_TOKEN']
+
+          debug { 'Loading cloud configuration from ENV' }
+          accounts << Account.new(kontena_account_data.merge(
+            token: Token.new(access_token: ENV['KONTENA_CLOUD_TOKEN'], parent_type: :account, parent_name: 'default')
+          ))
         end
       end
     end


### PR DESCRIPTION
Allows to set just `KONTENA_CLOUD_TOKEN`.

See: https://github.com/kontena/kontena/pull/3013