### PR TITLE
Fix kontena cloud ir create to not send double-encoded JSON

### DIFF
--- a/lib/kontena/plugin/cloud/image/create_command.rb
+++ b/lib/kontena/plugin/cloud/image/create_command.rb
@@ -19,7 +19,7 @@ class Kontena::Plugin::Cloud::Image::CreateCommand < Kontena::Command
       }
     }
     spinner "Creating image repository #{pastel.cyan(name)}" do
-      image_registry_client.post("/repositories", JSON.dump(body))
+      image_registry_client.post("/repositories", body)
     end
   end
 


### PR DESCRIPTION
Fixes #54 

The `image_registry_client` already does a `JSON.dump` for the body.
