### PR TITLE
Make image ls command to prompt org if not parseable from current master

### DIFF
--- a/lib/kontena/plugin/cloud/image/common.rb
+++ b/lib/kontena/plugin/cloud/image/common.rb
@@ -1,7 +1,10 @@
 require_relative '../../../cli/models/image_repo'
 require_relative '../../../cli/models/image_tag'
+require_relative '../organization/common'
 
 module Kontena::Plugin::Cloud::Image::Common
+  include Kontena::Plugin::Cloud::Organization::Common
+
   def image_registry_client
     @compute_client ||= Kontena::Client.new(image_registry_url, config.current_account.token, prefix: '/')
   end
@@ -15,10 +18,11 @@ module Kontena::Plugin::Cloud::Image::Common
   end
 
   def default_org
-    unless current_master
-      exit_with_error "Organization is required"
+    if current_master && current_master.name.include?('/')
+      org, _ = current_master.name.split('/')
+    else
+      org = prompt_organization
     end
-    org, _ = current_master.name.split('/')
 
     org
   end


### PR DESCRIPTION
## Before
```
jussi at troutbum in ~/code/kontena-plugin-cloud on fix/image-default-org [!]
$ kontena master use mac
Using master: mac (http://localhost)
Using grid: e2e

jussi at troutbum in ~/code/kontena-plugin-cloud on fix/image-default-org [!]
$ bundle exec kontena cloud ir ls
 [error] 401 : The access token has expired and needs to be refreshed
```

## After
```
jussi at troutbum in ~/code/kontena-plugin-cloud on fix/image-default-org [!]
$ bundle exec kontena cloud ir ls
> Choose organization jussi
NAME           PULLS   PUBLIC   CREATED
jussi/alpine   2       false    36 days ago

jussi at troutbum in ~/code/kontena-plugin-cloud on fix/image-default-org [!]
$ kontena cloud platform use jussi/packet-platform
Using platform: jussi/packet-platform

jussi at troutbum in ~/code/kontena-plugin-cloud on fix/image-default-org [!]
$ bundle exec kontena cloud ir ls
NAME           PULLS   PUBLIC   CREATED
jussi/alpine   2       false    36 days ago
```

